### PR TITLE
ci: add branch rules and stage area

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,7 @@ name: Main Pipeline
 
 on:
   push:
-    branches:
-      - main
+    branches: [dev, staged]
   pull_request:
     branches: [main]
     type: [opened, synchronized]


### PR DESCRIPTION
I want to protect the main (current live version) and the stage (the new version) branches from breaking change while updating to typescript