### PR TITLE
ci: removed workflow on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,8 @@
 name: Main Pipeline
 
 on:
-  push:
-    branches: [dev, staged]
   pull_request:
-    branches: [main]
+    branches: [main, staged]
     type: [opened, synchronized]
 
 jobs:


### PR DESCRIPTION
will run on pr's to the main branch instead by using github branch rules